### PR TITLE
Add Public URL Support to S3 Storage

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,8 +6,7 @@ dependencies:
     github: martenframework/marten
   awscr-s3:
     github: taylorfinnell/awscr-s3
-    branch: master # TODO: Change to next version after endpoint is added
-
+    version: ~> 0.10.0
 development_dependencies:
   sqlite3:
     github: crystal-lang/crystal-sqlite3

--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ dependencies:
     github: martenframework/marten
   awscr-s3:
     github: taylorfinnell/awscr-s3
-    version: ~> 0.9.0
+    branch: master # TODO: Change to next version after endpoint is added
 
 development_dependencies:
   sqlite3:

--- a/spec/marten_s3/store_spec.cr
+++ b/spec/marten_s3/store_spec.cr
@@ -167,7 +167,7 @@ describe MartenS3::Store do
         query_params.has_key?("X-Amz-Signature").should be_true
       end
 
-      it "returns a path-style public URL when `use_public_url` is true and `force_path_style` is enabled" do
+      it "returns a path-style public URL when `public_urls` is true and `force_path_style` is enabled" do
         storage = MartenS3::Store.new(
           region: "unused",
           bucket: bucket_name,
@@ -175,7 +175,7 @@ describe MartenS3::Store do
           secret_key: ENV.fetch("S3_SECRET", "password"),
           endpoint: ENV.fetch("S3_ENDPOINT", "http://127.0.0.1:9000"),
           force_path_style: true,
-          use_public_url: true,
+          public_urls: true,
         )
         uri = URI.parse(storage.url("css/app.css"))
 
@@ -186,14 +186,14 @@ describe MartenS3::Store do
         uri.query.should be_nil
       end
 
-      it "returns a virtual-host–style public URL when `use_public_url` is true and `force_path_style` is disabled" do
+      it "returns a virtual-host–style public URL when `public_urls` is true and `force_path_style` is disabled" do
         storage = MartenS3::Store.new(
           region: "unused",
           bucket: bucket_name,
           access_key: ENV.fetch("S3_KEY", "admin"),
           secret_key: ENV.fetch("S3_SECRET", "password"),
           endpoint: ENV.fetch("S3_ENDPOINT", "http://127.0.0.1:9000"),
-          use_public_url: true,
+          public_urls: true,
         )
         uri = URI.parse(storage.url("css/app.css"))
 

--- a/src/marten_s3/store.cr
+++ b/src/marten_s3/store.cr
@@ -10,6 +10,7 @@ module MartenS3
       @endpoint : String? = nil,
       @force_path_style : Bool = false,
       @expires_in = 86_400,
+      @use_public_url : Bool = false,
     )
       @client = Awscr::S3::Client.new(
         @region,
@@ -72,19 +73,34 @@ module MartenS3
     end
 
     def url(filepath : String) : String
-      generate_presigned_url(filepath)
+      filepath = URI.encode_path(filepath)
+
+      if @use_public_url
+        public_url(filepath)
+      else
+        generate_presigned_url(filepath)
+      end
     end
 
     private def public_url(filepath)
-      File.join(@endpoint.not_nil!, @bucket, URI.encode_path(filepath))
+      if @force_path_style
+        uri = @client.endpoint.dup
+        uri.path = "/#{@bucket}/#{filepath}"
+      else
+        uri = @client.endpoint.dup
+        uri.host = "#{@bucket}.#{@client.endpoint.host}"
+        uri.path = "/#{filepath}"
+      end
+
+      uri.to_s
     end
 
     private def generate_presigned_url(filepath : String)
       options = Awscr::S3::Presigned::Url::Options.new(
         aws_access_key: @access_key,
         aws_secret_key: @secret_key,
-        region: @region,
-        endpoint: @endpoint,
+        region: @client.region,
+        endpoint: @client.endpoint.to_s,
         bucket: @bucket,
         force_path_style: @force_path_style,
         object: filepath,

--- a/src/marten_s3/store.cr
+++ b/src/marten_s3/store.cr
@@ -83,11 +83,10 @@ module MartenS3
     end
 
     private def public_url(filepath)
+      uri = @client.endpoint.dup
       if @force_path_style
-        uri = @client.endpoint.dup
         uri.path = "/#{@bucket}/#{filepath}"
       else
-        uri = @client.endpoint.dup
         uri.host = "#{@bucket}.#{@client.endpoint.host}"
         uri.path = "/#{filepath}"
       end

--- a/src/marten_s3/store.cr
+++ b/src/marten_s3/store.cr
@@ -10,7 +10,7 @@ module MartenS3
       @endpoint : String? = nil,
       @force_path_style : Bool = false,
       @expires_in = 86_400,
-      @use_public_url : Bool = false,
+      @public_urls : Bool = false,
     )
       @client = Awscr::S3::Client.new(
         @region,
@@ -75,7 +75,7 @@ module MartenS3
     def url(filepath : String) : String
       filepath = URI.encode_path(filepath)
 
-      if @use_public_url
+      if @public_urls
         public_url(filepath)
       else
         generate_presigned_url(filepath)


### PR DESCRIPTION
This PR introduces support for generating public URLs for files stored via the `MartenS3::Store` class, using either path-style or virtual-host–style access depending on the configuration.

Closes #1 